### PR TITLE
Fixes issues with configuration in general and with fonts 0x10-0x1f.

### DIFF
--- a/common/config.c
+++ b/common/config.c
@@ -94,7 +94,9 @@ bool DELAYED_COPY_CODE(parse_config)(uint32_t address) {
                 break;
 #ifdef FUNCTION_VGA
             case CFGTOKEN_FONT_00:
-                romx_textbank = (config[i] >> 16) & 0x2F;
+                romx_textbank = (config[i] >> 16) & 0x3F;
+                if (romx_textbank >= FONT_COUNT)
+                   romx_textbank = 0;
                 romx_changed = 1;
                 break;
             case CFGTOKEN_MONO_00:
@@ -310,7 +312,7 @@ int DELAYED_COPY_CODE(make_config)(uint32_t rev) {
 #endif
 
 #ifdef FUNCTION_VGA
-    config_temp[i++] = CFGTOKEN_FONT_00 | ((romx_textbank & 0x2F) << 16);
+    config_temp[i++] = CFGTOKEN_FONT_00 | ((romx_textbank & 0x3F) << 16);
     config_temp[i++] = CFGTOKEN_MONO_00 | ((mono_palette & 0xF) << 20);
     config_temp[i++] = CFGTOKEN_TBCOLOR | ((terminal_tbcolor & 0xFF) << 16);
     config_temp[i++] = CFGTOKEN_BORDER | ((terminal_border & 0xF) << 16);
@@ -669,7 +671,9 @@ void DELAYED_COPY_CODE(config_handler)() {
                     // One-time load of font data (lost at reboot)
                     retval = test_font();
                 case 'S':
-                    romx_textbank = param0 & 0x2F;
+                    romx_textbank = param0 & 0x3F;
+                    if (romx_textbank >= FONT_COUNT)
+                          romx_textbank = 0;
                     romx_changed = 1;
                     retval = REPLY_OK;
 #endif

--- a/common/config.c
+++ b/common/config.c
@@ -375,8 +375,8 @@ bool DELAYED_COPY_CODE(is_primary_config_newer)() {
 }
 #endif
 
-bool DELAYED_COPY_CODE(read_config)() {
-    if(is_config_valid(FLASH_CONFIG_ONETIME)) {
+bool DELAYED_COPY_CODE(read_config)(bool onetime) {
+    if(onetime && is_config_valid(FLASH_CONFIG_ONETIME)) {
         internal_flags &= ~IFLAGS_TEST;
         soft_switches |= SOFTSW_TEXT_MODE;
         if(parse_config(FLASH_CONFIG_ONETIME))
@@ -772,7 +772,7 @@ void DELAYED_COPY_CODE(config_handler)() {
                 case 'b':
                     // Reboot and bypass auto-detection of machine type.
                     cfg_machine = current_machine;
-                    read_config();
+                    read_config(false);
                     write_config(true);
                     flash_reboot();
                     break;

--- a/common/config.h
+++ b/common/config.h
@@ -102,7 +102,7 @@ extern volatile compat_t current_machine;
 
 void default_config();
 int make_config(uint32_t rev);
-bool read_config();
+bool read_config(bool onetime);
 bool write_config(bool onetime);
 
 void config_handler();

--- a/common/main.c
+++ b/common/main.c
@@ -218,7 +218,7 @@ int main() {
     dmacpy32(__ram_delayed_copy_start__, __ram_delayed_copy_end__, __ram_delayed_copy_source__);
 
     // Load the config from flash, or defaults
-    read_config();
+    read_config(true);
 
 #if defined(FUNCTION_Z80) && defined(ANALOG_GS)
     uart_init(uart0, sio[0].baudrate);


### PR DESCRIPTION
See commit comments:

-  Fixed configuration: ONETIME vs PRIMARY.
    Configuration was no longer working. The firmware was always reading the
    ONETIME configuration section, while the config utility was writing the
    PRIMARY section. And there was no way to wipe/invalidate the ONETIME
    section, so the configuration utility had no effect.
    Also, the "reboot" command was reading and rewriting the ONETIME config
    section, so nothing changed.
    There are several way to fix the configuration utility - depending on what
    was actually intended with the ONETIME vs PRIMARY sections. This is one way
    to fix the issue: a reboot now reads the PRIMARY section and writes it to
    ONETIME.


- Fixed bit mask for font configuration.
    Fonts 0x10-0x1f could not be selected, since bit mask 0x2F always forced bit 4 to 0.
   The firmware supports 40 fonts (0x00-0x2F). However,  0x2F is not a multiple of 2,
   hence a simple bit mask cannot be used to mask the valid range.
    => Replaced with bit mask 0x3F, and added a separate range check for "FONT_COUNT".
